### PR TITLE
Fix build/release cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           path: |
             build/
-          key: ${{ github.sha }}-${{ matrix.os }}-${{ matrix.arch }}
+          key: ${{ github.run_id }}-${{ matrix.os }}-${{ matrix.arch }}
 
       - name: Setting version from git
         id: get_version
@@ -77,7 +77,7 @@ jobs:
         with:
           path: |
             build/
-          key: ${{ github.sha }}-${{ matrix.os }}-${{ matrix.arch }}
+          key: ${{ github.run_id }}-${{ matrix.os }}-${{ matrix.arch }}
 
       - name: Setting version from git
         id: get_version


### PR DESCRIPTION
git SHA was not specific enough in case we rebuild things in different branches. This is guaranteed to be unique per run