### PR TITLE
Throttle api calls when searching for a source tracking plan

### DIFF
--- a/segment/resource_source.go
+++ b/segment/resource_source.go
@@ -414,6 +414,7 @@ func findTrackingPlanSourceConnection(source string, client segment.Client) (str
 				return tpID, nil
 			}
 		}
+		// Segment API rate-limits at 60 calls/sec, so we delay the next call to avoid getting a 429
 		time.Sleep(configApiDelay)
 	}
 


### PR DESCRIPTION
Segment config API has a 60/s limit which prevents us from making repeated calls to find the tracking plan for a source. adding a bit of delay between each call prevents reaching that limit