### PR TITLE
Add source to destination filter

### DIFF
--- a/examples/resources/segment_destination_filter/resource.tf
+++ b/examples/resources/segment_destination_filter/resource.tf
@@ -1,6 +1,6 @@
 # Filter to drop events
 resource "segment_destination_filter" "drop_events" {
-  destination = "test_destination"
+  destination = "test_source/test_destination"
   title       = "Checkout events only"
   description = "Only send checkout events to destination"
   condition   = "event != \"Checkout\"" # Invert condition to drop all events but `Checkout`
@@ -12,7 +12,7 @@ resource "segment_destination_filter" "drop_events" {
 
 # Filter to sample data
 resource "segment_destination_filter" "sample_events" {
-  destination = "test_destination"
+  destination = "test_source/test_destination"
   title       = "Users accepting marketing"
   description = "Sends 10% of users accepting marketing permissions"
   condition   = "context.castPermissions.marketing = true"
@@ -27,7 +27,7 @@ resource "segment_destination_filter" "sample_events" {
 
 # Filter to block fields
 resource "segment_destination_filter" "checkout_block_ip_postcode" {
-  destination = "test_destination"
+  destination = "test_source/test_destination"
   title       = "No IP and postcode on Checkout"
   description = "Prevents IP address and postcode being sent on checkout"
   condition   = "event == \"Checkout\""
@@ -42,7 +42,7 @@ resource "segment_destination_filter" "checkout_block_ip_postcode" {
 
 # Filter to allow fields
 resource "segment_destination_filter" "checkout_allow_price_product" {
-  destination = "test_destination"
+  destination = "test_source/test_destination"
   title       = "Checkout price and product only"
   description = "Allows only price and product fields to go through on a Checkout event"
   condition   = "event == \"Checkout\""


### PR DESCRIPTION
Very difficult to figure out you had should provide the destination id with `source/destination`.
It gave crashes without it.
Would be better to have source as a separate property